### PR TITLE
Add reproducibility note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,7 @@ python com.py \
 ```
 
 This automatically identifies which layers are most important for communication and selects them for the main evaluation.
+
+### Reproducibility note
+
+The repository does not currently include the code used for FLOPs and memory measurement. Clarification on the exact measurement setup (e.g., execution path and whether lm_head is included) would be helpful for reproducing the reported results.


### PR DESCRIPTION
Hi! Thank you for releasing the code — it has been very helpful for reproducing the results.

While going through the implementation, I noticed that the repository does not seem to include the code used for FLOPs and memory measurement, so I wanted to ask a clarification question here for reproducibility.

In the current implementation:
- KVComm appears to use a `forward()` pass for the sender, which computes logits over all context tokens,
- while Skyline uses `generate()`, which (during prefill) computes logits only for the last token.

This made me wonder whether there might be any asymmetry in how FLOPs are being counted between the two methods.

Could you clarify how FLOPs were measured in the experiments? In particular:
- whether the `lm_head` computation was included or excluded,
- whether both methods were evaluated under a consistent execution path (e.g., both using `forward()` or both using `generate()`),
- or if there is another detail in the measurement setup that I might be missing.

If available, it would also be very helpful to know whether the FLOPs/memory measurement code can be shared.

Thanks again for the great work!